### PR TITLE
Pin truffle version 0.5.27 and solc 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaleido-io/truffle-kaleido-box",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Boilerplate to get up and running quickly with Truffle on a Kaleido chain.",
   "main": "truffle-config.js",
   "directories": {
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "retry": "^0.12.0",
-    "truffle": "^5.0.27",
+    "truffle": "5.0.27",
     "web3": "1.0.0-beta.37"
   },
   "devDependencies": {},

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   compilers: {
     solc: {
-      version: "0.5.8",
+      version: "0.5.0",
       settings: {
         evmVersion: "byzantium"
       }


### PR DESCRIPTION
quorum 2.3.0 has issues working with newer truffle versions and/or also
with solc 0.5.8 which is the default for the latest version. I tried to
run newer truffle with solc 0.5.0 but that still resulted in errors for
me. Hence pinning the version to a previous known working tuple