### PR TITLE
Enhance logging and disable confirmation listener to avoid spam

### DIFF
--- a/lib/http-provider-rate-limit-retry.js
+++ b/lib/http-provider-rate-limit-retry.js
@@ -34,11 +34,13 @@ var XHR2 = require('xhr2-cookies').XMLHttpRequest // jshint ignore: line
 var http = require('http');
 var https = require('https');
 
-DEBUG = process.env.DEBUG && true
-function log() {
+INFO = ['true','info'].includes(process.env.JSON_RPC_LOGGING);
+DEBUG = !!process.env.DEBUG || (process.env.JSON_RPC_LOGGING === 'debug');
+function log(infoArg, ...debugArgs) {
   if (DEBUG) {
-    let logArgs = [new Date().toISOString()].concat(Array.prototype.slice.call(arguments));
-    console.log.call(console, logArgs);
+    console.log(`${new Date().toISOString()}: `, infoArg, ...debugArgs);
+  } else if (INFO) {
+    console.log(`${new Date().toISOString()}: `, infoArg);
   }
 }
 
@@ -80,12 +82,16 @@ HTTPProviderRateLimitRetry.prototype._prepareRequest = function(){
 };
 
 HTTPProviderRateLimitRetry.prototype.send = function (payload, cb) {
-  var operation = retry.operation();
+  var operation = retry.operation({
+    minTimeout: 250,
+    maxTimeout: 5000,
+    randomize:  true,
+  });
   var self = this;
   operation.attempt(function(currentAttempt) {
     self.attemptSend(payload, function(err, result) {
       if (err && err.retryable && operation.retry(err)) {
-        log("Backoff retry attempt " + currentAttempt);
+        log(`JSON/RPC --> ${payload.id}:${payload.method} backoff-retry attempt ${currentAttempt}`);
         return;
       }
       cb(err ? operation.mainError() : null, result);
@@ -103,21 +109,23 @@ HTTPProviderRateLimitRetry.prototype.send = function (payload, cb) {
 HTTPProviderRateLimitRetry.prototype.attemptSend = function(payload, callback) {
     var _this = this;
 
-    log("JSON/RPC --> " + inspect(payload));
+    const startTime = Date.now();
+    log(`JSON/RPC --> ${payload.id}:${payload.method}`, payload);
 
     var request = this._prepareRequest();
 
     request.onreadystatechange = function() {
-          log("JSON/RPC <-- [" + request.status + "] " + request.responseText);
 
           if (request.readyState === 4 && request.timeout !== 1) {
+            log(`JSON/RPC <-- ${payload.id}:${payload.method} [${request.status}] ${Date.now() - startTime}ms`, request.responseText);
+
             var result = request.responseText;
             var error = null;
 
             try {
                 result = JSON.parse(result);
             } catch(e) {
-                log("JSON/RPC !-- Failed to parse '" + result + "': " + (e && e.stack || e));
+                if (DEBUG) log("JSON/RPC !-- Failed to parse '" + result + "': " + (e && e.stack || e));
                 error = errors.InvalidResponse(request.responseText);
                 error.retryable = true;
             }
@@ -132,7 +140,7 @@ HTTPProviderRateLimitRetry.prototype.attemptSend = function(payload, callback) {
     };
 
     request.ontimeout = function() {
-      log("JSON/RPC <-- TIMEOUT");
+      log(`JSON/RPC <-- ${payload.id}:${payload.method} TIMEOUT ${Date.now() - startTime}ms`)
 
       _this.connected = false;
         callback(errors.ConnectionTimeout(this.timeout));
@@ -141,7 +149,7 @@ HTTPProviderRateLimitRetry.prototype.attemptSend = function(payload, callback) {
     try {
         request.send(JSON.stringify(payload));
     } catch(error) {
-        log("JSON/RPC <-- SEND FAILED: " + (error && error.stack || error));
+        log(`JSON/RPC <-- ${payload.id}:${payload.method} SEND FAILED ${Date.now() - startTime}ms: ${err}`, err.stack)
   
         this.connected = false;
         callback(errors.InvalidConnection(this.host));

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -7,12 +7,15 @@ module.exports = {
     development: {
       provider: () => {
         const appCred = 'yourappcred'; // from application credential widget
-        const connectionURL = 'nodeConnectionURL'; // without protocol (https://)
+        const connectionURL = 'nodeConnectionURL'; // without protocol (https://)        
         return new HTTPProviderRateLimitRetry(`https://${appCred}@${connectionURL}`, 100000);
       },
       network_id: "*", // Match any network id
       gasPrice: 0,
       gas: 4500000,
+      disableConfirmationListener: true, // generates thousands of eth_getBlockByNumber calls
+      timeoutBlocks: 3,
+      deploymentPollingInterval: 5000,
       /* type: 'quorum' // Use this property for Quorum environments */
     },
   },


### PR DESCRIPTION
- Tweaks the retry config on the back-off retry listener
- Improves the logging
  - `JSON_RPC_LOGGING=info` (or `JSON_RPC_LOGGING=true`) gives succinct method/timing info
  - `JSON_RPC_LOGGING=debug` (or `DEBUG=true` for backward compat) gives full arguments and responses
- Sets `disableConfirmationListener` to disable the thousands of calls to `eth_getBlockByNumber`
  - See https://github.com/trufflesuite/truffle/issues/3522